### PR TITLE
Fix issue with running reports and old version of guava being version us...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,9 @@ dependencies {
 
     compile 'org.jbehave:jbehave-core:3.9.5'
     compile 'de.codecentric:jbehave-junit-runner:1.1.0'
-    compile 'org.reflections:reflections:0.9.8'
+    compile ('org.reflections:reflections:0.9.8') {
+        exclude group: 'guava', module: 'guava'
+    }
     compile 'com.googlecode.lambdaj:lambdaj:2.3.3'
     compile("org.codehaus.groovy:groovy-all:2.3.3")
 


### PR DESCRIPTION
...ed

If using Maven, and only define a dependency on serenity:serenity-jbehave, Maven
appears to resolve guava to the old version contained in reflections (0.11.0).

This version of Guava does not contain many of the methods required to complete reporting.

Adding this exclusion has all the tests pass, AND my FT suite completes successfully pointing at a
local SNAPSHOT version of this project.

I'm not sure where relfections is used. There is a 0.9.9 version available that depends on Guava 15, so we may want to upgrade to that, but I did the simplest thing that appears to work.
