### PR TITLE
upgrading serenity-core from 1.1.22-rc.15 to 1.1.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.22-rc.15'
+    serenityCoreVersion = '1.1.24'
 
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''


### PR DESCRIPTION
#### Summary of this PR
Upgrading serenity-core  from 1.1.22-rc.15 to 1.1.24
#### Intended effect
Usage of serenity-core of last version
#### How should this be manually tested?
./gradlew build will use serenity-core 1.1.24, also it can be tested using `gradle dependencies` command
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A