### PR TITLE
Updating dependency for using last serenity core, fixing issue with Java 8 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.25-rc.4'
+    serenityCoreVersion = '1.1.25-rc.5'
 
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.24'
+    serenityCoreVersion = '1.1.25-rc.4'
 
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
@@ -105,8 +105,9 @@ artifacts {
 configurations.all {
     resolutionStrategy {
         failOnVersionConflict()
-        force  "junit:junit:${junitVersion}"
-        force  "org.mockito:mockito-core:${mockitoCoreVersion}"
+        force "junit:junit:${junitVersion}",
+            "org.mockito:mockito-core:${mockitoCoreVersion}",
+            "commons-collections:commons-collections:3.2.2"
     }
 }
 
@@ -115,11 +116,14 @@ dependencies {
     compile 'commons-logging:commons-logging:1.2'
 
     compile 'com.thoughtworks.xstream:xstream:1.4.5'
+    compile 'com.thoughtworks.paranamer:paranamer:2.7'
 
     compile("org.jbehave:jbehave-core:${jbehaveCoreVersion}") {
         exclude group: 'org.freemarker', module: 'freemarker'
         exclude group: 'junit', module: 'junit'
         exclude group: 'com.thoughtworks.xstream', module: 'xstream'
+        exclude group: 'commons-collections', module: 'commons-collections'
+        exclude group: 'com.thoughtworks.paranamer', module : 'paranamer'
     }
 
     compile('de.codecentric:jbehave-junit-runner:1.2.0') {
@@ -265,6 +269,6 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 task copyDeps(type: Copy) {
-    from configurations.runtime
+    from configurations.runtime + configurations.testCompile
     into project.projectDir.path+"/lib"
 }

--- a/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
+++ b/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
@@ -520,7 +520,7 @@ public class SerenityReporter implements StoryReporter {
         if (isPendingScenario()) {
             StepEventBus.getEventBus().testPending();
         } else if (isSkippedScenario()) {
-            StepEventBus.getEventBus().testIgnored();
+            StepEventBus.getEventBus().testSkipped();
         }
 
     }

--- a/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
+++ b/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
@@ -248,7 +248,7 @@ public class SerenityReporter implements StoryReporter {
     Map<Story, WebDriver> drivers = Maps.newConcurrentMap();
 
     private void configureDriver(Story story) {
-        StepEventBus.getEventBus().setUniqueSession(systemConfiguration.getUseUniqueBrowser());
+        StepEventBus.getEventBus().setUniqueSession(systemConfiguration.shouldUseAUniqueBrowser());
         String requestedDriver = getRequestedDriver(story.getMeta());
         if (StringUtils.isNotEmpty(requestedDriver)) {
             ThucydidesWebDriverSupport.initialize(requestedDriver);

--- a/src/test/java/net/serenitybdd/jbehave/WhenRunningWebJBehaveStories.java
+++ b/src/test/java/net/serenitybdd/jbehave/WhenRunningWebJBehaveStories.java
@@ -110,7 +110,7 @@ public class WhenRunningWebJBehaveStories extends AbstractJBehaveStory {
 
         assertThat(story.getSystemConfiguration().getBaseUrl(), is("some-base-url"));
         assertThat(story.getSystemConfiguration().getElementTimeout(), is(5));
-        assertThat(story.getSystemConfiguration().getUseUniqueBrowser(), is(true));
+        assertThat(story.getSystemConfiguration().shouldUseAUniqueBrowser(), is(true));
     }
 
     @Test(expected = Throwable.class)


### PR DESCRIPTION
#### Summary of this PR
Updating dependency for using last serenity core
#### Intended effect
Will be used commons-collections:commons-collections:3.2.2 instead of 3.2.1 as in selenium 2.50.1. 
Also junit with version 4.12 will be used. com.thoughtworks.paranamer:paranamer:2.7 will be used
#### How should this be manually tested?
Project with last serenity core should be build. Also java 8 can be used in jbehave tests
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A