### PR TITLE
feat: updated managed tag processing

### DIFF
--- a/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
+++ b/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
@@ -428,6 +428,10 @@ public class SerenityReporter implements StoryReporter {
         }
     }
 
+    private boolean isStoryManual(){
+        return isManual(currentStory().getMeta());
+    }
+
     private Optional<TestResult> getScenarioMetadataResult() {
        return forcedScenarioResult;
     }
@@ -437,7 +441,7 @@ public class SerenityReporter implements StoryReporter {
             forcedScenarioResult = Optional.of(TestResult.PENDING);
         } else if (isSkipped(metaData)) {
             forcedScenarioResult = Optional.of(TestResult.SKIPPED);
-        } else if (isManual(metaData)) {
+        } else if (isManual(metaData) || isStoryManual()) {
             StepEventBus.getEventBus().testIsManual();
             StepEventBus.getEventBus().suspendTest();
         }
@@ -522,7 +526,6 @@ public class SerenityReporter implements StoryReporter {
         } else if (isSkippedScenario()) {
             StepEventBus.getEventBus().testSkipped();
         }
-
     }
 
     private boolean isPending(Meta metaData) {

--- a/src/test/java/net/serenitybdd/jbehave/WhenRunningJBehaveStoriesManualTags.java
+++ b/src/test/java/net/serenitybdd/jbehave/WhenRunningJBehaveStoriesManualTags.java
@@ -1,0 +1,72 @@
+package net.serenitybdd.jbehave;
+
+import net.thucydides.core.model.TestOutcome;
+import net.thucydides.core.model.TestResult;
+import net.thucydides.core.model.TestTag;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+import static net.thucydides.core.reports.matchers.TestOutcomeMatchers.havingTag;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class WhenRunningJBehaveStoriesManualTags extends AbstractJBehaveStory {
+
+    @Test
+    public void a_test_should_be_marked_as_manual_when_manual_tag_provided() throws Throwable {
+
+        // Given
+        SerenityStories story = newStory("aBehaviorWithManualScenario.story");
+
+        // When
+        run(story);
+
+        // Then
+        List<TestOutcome> outcomes = loadTestOutcomes();
+        assertThat(outcomes.get(0), havingTag(TestTag.withName("Manual").andType("External Tests")));
+        assertThat(outcomes.get(0).isManual(), equalTo(true));
+        assertThat(outcomes.get(0).getResult(), is(TestResult.PENDING));
+    }
+
+    @Test
+    public void steps_should_be_marked_manual_if_tag_provided_at_story_level() throws Throwable {
+
+        // Given
+        SerenityStories story = newStory("aBehaviorWithManualStory.story");
+
+        // When
+        run(story);
+
+        // Then
+        List<TestOutcome> outcomes = loadTestOutcomes();
+        assertThat(outcomes.get(0), havingTag(TestTag.withName("Manual").andType("External Tests")));
+        assertThat(outcomes.get(0).isManual(), equalTo(true));
+        assertThat(outcomes.get(0).getResult(), is(TestResult.PENDING));
+        assertThat(outcomes.get(1), havingTag(TestTag.withName("Manual").andType("External Tests")));
+        assertThat(outcomes.get(1).isManual(), equalTo(true));
+        assertThat(outcomes.get(1).getResult(), is(TestResult.PENDING));
+
+    }
+
+    @Test
+    public void scenario_manual_tags_should_not_be_shared_between_scenarios() throws Throwable {
+
+        // Given
+        SerenityStories story = newStory("aBehaviorWithManualAndNotManualScenario.story");
+
+        // When
+        run(story);
+
+        // Then
+        List<TestOutcome> outcomes = loadTestOutcomes();
+        assertThat(outcomes.get(0), havingTag(TestTag.withName("Manual").andType("External Tests")));
+        assertThat(outcomes.get(0).isManual(), equalTo(true));
+        assertThat(outcomes.get(0).getResult(), is(TestResult.PENDING));
+
+        assertThat(outcomes.get(1).getResult(), is(TestResult.SUCCESS));
+        assertThat(outcomes.get(1).isManual(), equalTo(false));
+        assertThat(outcomes.get(1).getTags().size(), is(1));
+    }
+}

--- a/src/test/resources/stories/aBehaviorWithManualAndNotManualScenario.story
+++ b/src/test/resources/stories/aBehaviorWithManualAndNotManualScenario.story
@@ -1,0 +1,22 @@
+Narrative:
+In order to provide some business value
+As a user
+I want to perform an action
+
+Scenario: A scenario that works and should be manual
+Meta:
+@manual
+
+Given I have an implemented JBehave scenario
+And the scenario works
+When I run the scenario
+Then I should get a successful result
+
+Scenario: A scenario that works and should not be manual
+
+Given I have an implemented JBehave scenario
+And the scenario works
+When I run the scenario
+Then I should get a successful result
+
+

--- a/src/test/resources/stories/aBehaviorWithManualScenario.story
+++ b/src/test/resources/stories/aBehaviorWithManualScenario.story
@@ -1,0 +1,13 @@
+Narrative:
+In order to provide some business value
+As a user
+I want to perform an action
+
+Scenario: A scenario that works and should me manual
+Meta:
+@manual
+
+Given I have an implemented JBehave scenario
+And the scenario works
+When I run the scenario
+Then I should get a successful result

--- a/src/test/resources/stories/aBehaviorWithManualStory.story
+++ b/src/test/resources/stories/aBehaviorWithManualStory.story
@@ -1,0 +1,18 @@
+Narrative:
+In order to provide some business value
+As a user
+I want to perform an action
+
+Meta:
+@manual
+Scenario: A scenario that works and should me manual
+Given I have an implemented JBehave scenario
+And the scenario works
+When I run the scenario
+Then I should get a successful result
+
+Scenario: A scenario that works and should me manual too
+Given I have an implemented JBehave scenario
+And the scenario works
+When I run the scenario
+Then I should get a successful result


### PR DESCRIPTION
#### Summary of this PR
Updating @manual tag processing, adding new tests. 
#### Intended effect
Now it is possible to mark as manages all scenarious in story file
```
Narrative:
...
Meta:
@manual
Scenario: A scenario that works and should me manual
Given I have an implemented JBehave scenario
...
Scenario: A scenario that works and should me manual too
Given I have an implemented JBehave scenario
...
```

#### How should this be manually tested?
Some project can be created with story where Meta: @manual provided on story level but not scenario level - all scenarios in this story should be marked as manual
#### Side effects
N/A
#### Documentation
serenity-bdd/serenity-documentation/issues/59
#### Relevant tickets
#43 
#### Screenshots (if appropriate)
N/A