### PR TITLE
Updated loader of testOutcomes to use serenity core utilites

### DIFF
--- a/src/test/java/net/serenitybdd/jbehave/AbstractJBehaveStory.java
+++ b/src/test/java/net/serenitybdd/jbehave/AbstractJBehaveStory.java
@@ -3,6 +3,7 @@ package net.serenitybdd.jbehave;
 import net.serenitybdd.jbehave.runners.SerenityReportingRunner;
 import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.model.TestStep;
+import net.thucydides.core.reports.TestOutcomeLoader;
 import net.thucydides.core.reports.xml.XMLTestOutcomeReporter;
 import net.thucydides.core.util.MockEnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
@@ -77,16 +78,9 @@ public class AbstractJBehaveStory {
     }
 
     protected List<TestOutcome> loadTestOutcomes() throws IOException {
-
-        XMLTestOutcomeReporter outcomeReporter = new XMLTestOutcomeReporter();
+        TestOutcomeLoader loader = new TestOutcomeLoader();
         System.out.println("Loading test outcomes from " + outputDirectory);
-        List<TestOutcome> testOutcomes = outcomeReporter.loadReportsFrom(outputDirectory);
-        Collections.sort(testOutcomes, new Comparator<TestOutcome>() {
-            public int compare(TestOutcome testOutcome, TestOutcome testOutcome1) {
-                return testOutcome.getTitle().compareTo(testOutcome1.getTitle());
-            }
-        });
-        return testOutcomes;
+        return loader.loadFrom(outputDirectory);
     }
 
 


### PR DESCRIPTION
#### Summary of this PR
Updated loader of testOutcomes to use serenity core utilites
#### Intended effect
Will be used serenity-core utilities for loading test outcomes 
#### How should this be manually tested?
Create some project and execute tests of it with serenity jbehave - all should work fine
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
serenity-bdd/serenity-core/issues/322,  #45 
#### Screenshots (if appropriate)
N/A