### PR TITLE
Changed loading of test classes. Now test classes can be loaded from directories and subdirectories based on root package

### DIFF
--- a/src/main/java/net/serenitybdd/jbehave/SerenityStepFactory.java
+++ b/src/main/java/net/serenitybdd/jbehave/SerenityStepFactory.java
@@ -13,6 +13,7 @@ import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.steps.AbstractStepsFactory;
 import org.jbehave.core.steps.CandidateSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +23,7 @@ import static ch.lambdaj.Lambda.convert;
 public class SerenityStepFactory extends AbstractStepsFactory {
 
     private static final ThreadLocal<SerenityStepContext> context = new ThreadLocal<SerenityStepContext>();
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SerenityStepFactory.class);
 
     private final String rootPackage;
     private ClassLoader classLoader;

--- a/src/main/java/net/serenitybdd/jbehave/SerenityStories.java
+++ b/src/main/java/net/serenitybdd/jbehave/SerenityStories.java
@@ -188,7 +188,21 @@ public class SerenityStories extends JUnitStories {
      * The root package on the classpath containing the JBehave stories to be run.
      */
     protected String getRootPackage() {
-        return this.getClass().getPackage().getName();
+        final Package current = this.getClass().getPackage();
+        final String path=current.getName();
+        String[] elements = path.split("\\.");
+        if (elements.length >= 1) {
+            elements = Arrays.copyOfRange(elements, 0, elements.length - 1);
+        }
+        return concatElements(elements);
+    }
+
+    private String concatElements(final String[] subpaths) {
+        final StringBuilder builder = new StringBuilder();
+        for (String path : subpaths) {
+            builder.append(path).append(".");
+        }
+        return builder.substring(0, builder.length() - 1);
     }
 
     protected List<String> getStoryPathExpressions() {
@@ -216,7 +230,6 @@ public class SerenityStories extends JUnitStories {
     public void findStoriesCalled(String storyNames) {
         Set<String> storyPathElements = new StoryPathFinder(getEnvironmentVariables(), storyNames).findAllElements();
         storyNamePattern = Lambda.join(storyPathElements, ";");
-
     }
 
 

--- a/src/test/java/net/serenitybdd/jbehave/WhenRunningASelectionOfJBehaveStories.java
+++ b/src/test/java/net/serenitybdd/jbehave/WhenRunningASelectionOfJBehaveStories.java
@@ -1,5 +1,7 @@
 package net.serenitybdd.jbehave;
 
+import net.serenitybdd.jbehave.samples.levels.first.SerenityStorySampleForFistLevel;
+import net.serenitybdd.jbehave.samples.levels.second.SerenityStorySampleForSecondLevel;
 import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.model.TestResult;
 import net.thucydides.core.util.EnvironmentVariables;
@@ -8,12 +10,10 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class WhenRunningASelectionOfJBehaveStories extends AbstractJBehaveStory {
-
-    final static class AllStoriesSample extends SerenityStories {
-    }
 
     final static class AStorySample extends SerenityStories {
 
@@ -30,9 +30,13 @@ public class WhenRunningASelectionOfJBehaveStories extends AbstractJBehaveStory 
     public void all_stories_on_the_classpath_should_be_run_by_default() throws Throwable {
 
         // Given
-        SerenityStories stories = new AllStoriesSample();
-        assertThat(stories.getRootPackage(), is("net.serenitybdd.jbehave"));
-        assertThat(stories.getStoryPath(), is("**/*.story"));
+        SerenityStories first = new SerenityStorySampleForFistLevel();
+        SerenityStories second = new SerenityStorySampleForSecondLevel();
+        // Then
+        assertThat(first.getRootPackage(), equalTo(second.getRootPackage()));
+        assertThat(first.getStoryPath(), equalTo(second.getStoryPath()));
+        assertThat(first.stepsFactory().createCandidateSteps().containsAll(second.stepsFactory().createCandidateSteps()), is(true));
+        assertThat(first.getStoryPath(), is("**/*.story"));
     }
 
     final static class StoriesInTheSubsetFolderSample extends SerenityStories {

--- a/src/test/java/net/serenitybdd/jbehave/samples/levels/first/SerenityStorySampleForFistLevel.java
+++ b/src/test/java/net/serenitybdd/jbehave/samples/levels/first/SerenityStorySampleForFistLevel.java
@@ -1,0 +1,6 @@
+package net.serenitybdd.jbehave.samples.levels.first;
+
+import net.serenitybdd.jbehave.SerenityStories;
+
+public class SerenityStorySampleForFistLevel extends SerenityStories {
+}

--- a/src/test/java/net/serenitybdd/jbehave/samples/levels/second/SerenityStorySampleForSecondLevel.java
+++ b/src/test/java/net/serenitybdd/jbehave/samples/levels/second/SerenityStorySampleForSecondLevel.java
@@ -1,0 +1,6 @@
+package net.serenitybdd.jbehave.samples.levels.second;
+
+import net.serenitybdd.jbehave.SerenityStories;
+
+public class SerenityStorySampleForSecondLevel extends SerenityStories {
+}


### PR DESCRIPTION
#### Summary of this PR
Changed loading of test classes. Now test classes can be loaded from directories and subdirectories based on root package
#### Intended effect
If some test in different packages, now they will be loaded and executed as well
#### How should this be manually tested?
Please refer to issue for more details 
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#54 
#### Screenshots (if appropriate)
N/A