### PR TITLE
Updated resetting If browser died it should be restarted even if not shouldRestartDriverBeforeEachScenario

### DIFF
--- a/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
+++ b/src/main/java/net/serenitybdd/jbehave/SerenityReporter.java
@@ -6,7 +6,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import gherkin.formatter.model.Tag;
 import net.serenitybdd.core.Serenity;
 import net.serenitybdd.core.SerenityListeners;
 import net.serenitybdd.core.SerenityReports;
@@ -42,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 
 import static ch.lambdaj.Lambda.*;
 
@@ -190,7 +188,10 @@ public class SerenityReporter implements StoryReporter {
         logger.debug("scenario started ".concat(scenarioTitle));
         clearScenarioResult();
 
-        if (shouldRestartDriverBeforeEachScenario() && !shouldNestScenarios()) {
+        if (managedDriverIsNotAlive()) {
+            WebdriverProxyFactory.resetDriver(ThucydidesWebDriverSupport.getDriver());
+        } else if (shouldRestartDriverBeforeEachScenario()
+                && !shouldNestScenarios()) {
             WebdriverProxyFactory.resetDriver(ThucydidesWebDriverSupport.getDriver());
         }
 
@@ -209,6 +210,15 @@ public class SerenityReporter implements StoryReporter {
                 scenarioMetaProcessed.add(scenarioTitle);
             }
         }
+    }
+
+    private boolean managedDriverIsNotAlive() {
+        try {
+            ThucydidesWebDriverSupport.getDriver().getTitle();
+        } catch (Exception e) {
+            return true;
+        }
+        return false;
     }
 
     private boolean isCurrentScenario(String scenarioTitle) {


### PR DESCRIPTION
#### Summary of this PR
Updated resetting If browser died it should be restarted even if not shouldRestartDriverBeforeEachScenario
#### Intended effect
If restart.browser.each.scenario=false  provided one browser will be used for all tests. If this browser crashed it will be restarted
#### How should this be manually tested?
Some long test should be created with big amount of steps and scenarios on one story file. 
restart.browser.each.scenario=false should be in serenity properties. 
After browser started execute all tests one by one - it should be closed manually (like browser crashed). For this scenario fail should be reported, and for next new instance of browser should be used. 
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
serenity-bdd/serenity-core/issues/363
#### Screenshots (if appropriate)
N/A