### PR TITLE
use MetaFilter before creating PerformableTree

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-serenityCoreVersion = 1.7.0
+serenityCoreVersion = 1.7.5
 
 groovyVersion = 2.4.11
 junitVersion = 4.12

--- a/src/main/java/net/serenitybdd/jbehave/runners/SerenityReportingRunner.java
+++ b/src/main/java/net/serenitybdd/jbehave/runners/SerenityReportingRunner.java
@@ -331,6 +331,7 @@ public class SerenityReportingRunner extends Runner {
 
     private PerformableTree createPerformableTree(List<String> storyPaths) {
         ExtendedEmbedder configuredEmbedder = this.getConfiguredEmbedder();
+        configuredEmbedder.useMetaFilters(getMetaFilters());
         BatchFailures failures = new BatchFailures(configuredEmbedder.embedderControls().verboseFailures());
         PerformableTree performableTree = new PerformableTree();
         RunContext context = performableTree.newRunContext(getConfiguration(), configuredEmbedder.stepsFactory(),


### PR DESCRIPTION
use Metafilter not just during test run, but also during building PerformableTree when prepare description for JUnit runner.
Fixes IDE presentation issue where first scenarios marked as executed instead of filtered ones