### PR TITLE
chore: added chmod +x gradlew to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 before_install:
+  - chmod +x gradlew
   - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
   - sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
   - wget -N http://chromedriver.storage.googleapis.com/2.11/chromedriver_linux64.zip


### PR DESCRIPTION
Should fix the build failures due to permission denied error.