### PR TITLE
refactor: simplify Joda-time converters via JBehave AbstractParameterConverter

### DIFF
--- a/src/main/java/net/serenitybdd/jbehave/converters/DateTimeConverter.java
+++ b/src/main/java/net/serenitybdd/jbehave/converters/DateTimeConverter.java
@@ -10,7 +10,7 @@ import org.joda.time.format.DateTimeFormatter;
 import java.lang.reflect.Type;
 import java.util.List;
 
-public class DateTimeConverter implements ParameterConverters.ParameterConverter {
+public class DateTimeConverter extends ParameterConverters.AbstractParameterConverter<DateTime> {
 
     public static final DateTimeFormatter CONVENTIONAL_FORMAT = DateTimeFormat.forPattern("ddMMyyyy");
     public static final DateTimeFormatter ISO_FORMAT = DateTimeFormat.forPattern("yyyyMMdd");
@@ -45,12 +45,7 @@ public class DateTimeConverter implements ParameterConverters.ParameterConverter
     }
 
     @Override
-    public boolean accept(Type type) {
-        return type instanceof Class<?> && DateTime.class.isAssignableFrom((Class<?>) type);
-    }
-
-    @Override
-    public Object convertValue(String value, Type type) {
+    public DateTime convertValue(String value, Type type) {
         DateTimeFormatter formatter = getBestFormatterFor(value);
         return DateTime.parse(normalized(value), formatter);
     }

--- a/src/main/java/net/serenitybdd/jbehave/converters/TimeConverter.java
+++ b/src/main/java/net/serenitybdd/jbehave/converters/TimeConverter.java
@@ -5,15 +5,10 @@ import org.joda.time.LocalTime;
 
 import java.lang.reflect.Type;
 
-public class TimeConverter implements ParameterConverters.ParameterConverter {
+public class TimeConverter extends ParameterConverters.AbstractParameterConverter<LocalTime> {
 
         @Override
-        public boolean accept(Type type) {
-            return type instanceof Class<?> && LocalTime.class.isAssignableFrom((Class<?>) type);
-        }
-
-        @Override
-        public Object convertValue(String value, Type type) {
+        public LocalTime convertValue(String value, Type type) {
             return LocalTime.parse(value);
         }
     }

--- a/src/main/java/net/serenitybdd/jbehave/converters/YearMonthConverter.java
+++ b/src/main/java/net/serenitybdd/jbehave/converters/YearMonthConverter.java
@@ -7,7 +7,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 import java.lang.reflect.Type;
 
-public class YearMonthConverter implements ParameterConverters.ParameterConverter {
+public class YearMonthConverter extends ParameterConverters.AbstractParameterConverter<YearMonth> {
     public static final DateTimeFormatter MONTH_YEAR_FORMAT_WITH_DASH = DateTimeFormat.forPattern("MM-yyyy");
     public static final DateTimeFormatter MONTH_YEAR_FORMAT_WITH_SLASH = DateTimeFormat.forPattern("MM/yyyy");
     public static final DateTimeFormatter YEAR_MONTH_FORMAT_WITH_DASH = DateTimeFormat.forPattern("yyyy-MM");
@@ -15,35 +15,20 @@ public class YearMonthConverter implements ParameterConverters.ParameterConverte
 
 
     @Override
-    public boolean accept(Type type) {
-        return type instanceof Class<?> && YearMonth.class.isAssignableFrom((Class<?>) type);
+    public YearMonth convertValue(String value, Type type) {
+        DateTimeFormatter formatter = hasDash(value) ? getFormatterWithDash(value) : getFormatterWithSlash(value);
+        return YearMonth.parse(value, formatter);
     }
 
-    @Override
-    public Object convertValue(String value, Type type) {
-        if (thereIsADashIn(value)) {
-            return parseWithDash(value);
-        }
-        return parseWithSlash(value);
+    private DateTimeFormatter getFormatterWithSlash(String value) {
+        return value.trim().charAt(2) == '/' ? MONTH_YEAR_FORMAT_WITH_SLASH : YEAR_MONTH_FORMAT_WITH_SLASH;
     }
 
-    private YearMonth parseWithSlash(String value) {
-        if (value.trim().substring(2,3).equals("/")) {
-            return YearMonth.parse(value, MONTH_YEAR_FORMAT_WITH_SLASH);
-        } else {
-            return YearMonth.parse(value, YEAR_MONTH_FORMAT_WITH_SLASH);
-        }
+    private DateTimeFormatter getFormatterWithDash(String value) {
+        return value.trim().charAt(2) == '-' ? MONTH_YEAR_FORMAT_WITH_DASH : YEAR_MONTH_FORMAT_WITH_DASH;
     }
 
-    private YearMonth parseWithDash(String value) {
-        if (value.trim().substring(2,3).equals("-")) {
-            return YearMonth.parse(value, MONTH_YEAR_FORMAT_WITH_DASH);
-        } else {
-            return YearMonth.parse(value, YEAR_MONTH_FORMAT_WITH_DASH);
-        }
-    }
-
-    private boolean thereIsADashIn(String value) {
-        return value.contains("-");
+    private boolean hasDash(String value) {
+        return value.indexOf('-') > -1;
     }
 }

--- a/src/test/java/net/serenitybdd/jbehave/converters/WhenConvertingJodaDateTimes.java
+++ b/src/test/java/net/serenitybdd/jbehave/converters/WhenConvertingJodaDateTimes.java
@@ -12,7 +12,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_convert_time_string_to_LocalTimes() {
         TimeConverter converter = new TimeConverter();
-        LocalTime convertedTime = (LocalTime) converter.convertValue("18:12", LocalTime.class);
+        LocalTime convertedTime = converter.convertValue("18:12", LocalTime.class);
 
         assertThat(convertedTime.getHourOfDay()).isEqualTo(18);
         assertThat(convertedTime.getMinuteOfHour()).isEqualTo(12);
@@ -21,7 +21,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_convert_date_string_to_LocalTimes() {
         DateTimeConverter converter = new DateTimeConverter();
-        DateTime convertedTime = (DateTime) converter.convertValue("10/04/1942", LocalTime.class);
+        DateTime convertedTime = converter.convertValue("10/04/1942", LocalTime.class);
 
         assertThat(convertedTime.getDayOfMonth()).isEqualTo(10);
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(4);
@@ -31,7 +31,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_convert_date_string_with_dashes_to_LocalTimes() {
         DateTimeConverter converter = new DateTimeConverter();
-        DateTime convertedTime = (DateTime) converter.convertValue("10-04-1942", LocalTime.class);
+        DateTime convertedTime = converter.convertValue("10-04-1942", LocalTime.class);
 
         assertThat(convertedTime.getDayOfMonth()).isEqualTo(10);
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(4);
@@ -41,7 +41,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_detect_iso_date_format() {
         DateTimeConverter converter = new DateTimeConverter();
-        DateTime convertedTime = (DateTime) converter.convertValue("1942-04-10", LocalTime.class);
+        DateTime convertedTime = converter.convertValue("1942-04-10", LocalTime.class);
 
         assertThat(convertedTime.getDayOfMonth()).isEqualTo(10);
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(4);
@@ -63,7 +63,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_detect_YearMonth_format() {
         YearMonthConverter converter = new YearMonthConverter();
-        YearMonth convertedTime = (YearMonth) converter.convertValue("10-1942", YearMonth.class);
+        YearMonth convertedTime = converter.convertValue("10-1942", YearMonth.class);
 
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(10);
         assertThat(convertedTime.getYear()).isEqualTo(1942);
@@ -72,7 +72,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_detect_MonthYear_format() {
         YearMonthConverter converter = new YearMonthConverter();
-        YearMonth convertedTime = (YearMonth) converter.convertValue("1942-10", YearMonth.class);
+        YearMonth convertedTime = converter.convertValue("1942-10", YearMonth.class);
 
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(10);
         assertThat(convertedTime.getYear()).isEqualTo(1942);
@@ -81,7 +81,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_detect_YearMonth_format_with_slash() {
         YearMonthConverter converter = new YearMonthConverter();
-        YearMonth convertedTime = (YearMonth) converter.convertValue("10/1942", YearMonth.class);
+        YearMonth convertedTime = converter.convertValue("10/1942", YearMonth.class);
 
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(10);
         assertThat(convertedTime.getYear()).isEqualTo(1942);
@@ -91,7 +91,7 @@ public class WhenConvertingJodaDateTimes {
     @Test
     public void should_detect_MonthYear_format_with_slash() {
         YearMonthConverter converter = new YearMonthConverter();
-        YearMonth convertedTime = (YearMonth) converter.convertValue("1942/10", YearMonth.class);
+        YearMonth convertedTime = converter.convertValue("1942/10", YearMonth.class);
 
         assertThat(convertedTime.getMonthOfYear()).isEqualTo(10);
         assertThat(convertedTime.getYear()).isEqualTo(1942);


### PR DESCRIPTION
Starting from version 4.2 JBehave provides generics-based abstraction layer for ParameterConverters, which simplifies creation of custom parameter converters